### PR TITLE
Integrate new version

### DIFF
--- a/me.simakis.dropboxignore.metainfo.xml
+++ b/me.simakis.dropboxignore.metainfo.xml
@@ -38,36 +38,36 @@
   </content_rating>
     <screenshots>
         <screenshot type="default">
-            <caption>dropboxognore ignore command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/ignore.png</image>
+            <caption>dropboxignore ignore command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/ignore.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore genupi command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/genupi.png</image>
+            <caption>dropboxignore genupi command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/genupi.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore list command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/list.png</image>
+            <caption>dropboxignore list command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/list.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore generate command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/generate.png</image>
+            <caption>dropboxignore generate command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/generate.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore delete command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/delete.png</image>
+            <caption>dropboxignore delete command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/delete.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore update command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/update.png</image>
+            <caption>dropboxignore update command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/update.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore revert command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/revert.png</image>
+            <caption>dropboxignore revert command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/revert.png</image>
         </screenshot>
         <screenshot>
-            <caption>dropboxognore help command usage</caption>
-            <image type="source">https://raw.githubusercontent.com/sp1thas/dropboxignore/master/docs/static/help.png</image>
+            <caption>dropboxignore help command usage</caption>
+            <image type="source">https://dropboxignore.simakis.me/static/screenshots/help.png</image>
         </screenshot>
     </screenshots>
     <releases>

--- a/me.simakis.dropboxignore.yml
+++ b/me.simakis.dropboxignore.yml
@@ -21,7 +21,7 @@ modules:
    sources:
      - type: git
        url: https://github.com/sp1thas/dropboxignore.git
-       commit: 2684ace4ec1fc95b0c6ec4102f1d9f21ed295d4c
+       commit: 18a58ea8febc3026298e7ce14655c15e3ebc72c6
      - type: file
        path: me.simakis.dropboxignore.metainfo.xml
      - type: file

--- a/me.simakis.dropboxignore.yml
+++ b/me.simakis.dropboxignore.yml
@@ -10,11 +10,12 @@ modules:
  - name: dropboxingore
    buildsystem: simple
    build-commands:
-     - install -D bin/dropboxignore.sh /app/bin/dropboxignore.sh
-     - install -Dm644 icons/64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png
-     - install -Dm644 icons/128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
-     - install -Dm644 icons/256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
-     - install -Dm644 icons/512.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+     - make install
+     - install -D /usr/local/bin/dropboxignore /app/bin/dropboxignore.sh
+     - install -Dm644 docs/static/icons/64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png
+     - install -Dm644 docs/static/icons/128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
+     - install -Dm644 docs/static/icons/256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
+     - install -Dm644 docs/static/icons/512.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
      - install -Dm644 --target-directory=/app/share/metainfo me.simakis.dropboxignore.metainfo.xml
      - install -Dm644 me.simakis.dropboxignore.desktop -t /app/share/applications
    sources:

--- a/me.simakis.dropboxignore.yml
+++ b/me.simakis.dropboxignore.yml
@@ -10,8 +10,7 @@ modules:
  - name: dropboxingore
    buildsystem: simple
    build-commands:
-     - sudo make install
-     - install -D src/bin/cli.sh /app/bin/dropboxignore.sh
+     - make install DESTSCRIPTNAME=dropboxignore.sh DESTBINDIR=/app/bin DESTLIBDIR=/app/lib
      - install -Dm644 docs/static/icons/64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png
      - install -Dm644 docs/static/icons/128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
      - install -Dm644 docs/static/icons/256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
@@ -21,7 +20,7 @@ modules:
    sources:
      - type: git
        url: https://github.com/sp1thas/dropboxignore.git
-       commit: 18a58ea8febc3026298e7ce14655c15e3ebc72c6
+       commit: 3744ac94585a6373500ec4290e32c3b61e55a932
      - type: file
        path: me.simakis.dropboxignore.metainfo.xml
      - type: file

--- a/me.simakis.dropboxignore.yml
+++ b/me.simakis.dropboxignore.yml
@@ -10,8 +10,8 @@ modules:
  - name: dropboxingore
    buildsystem: simple
    build-commands:
-     - make install
-     - install -D /usr/local/bin/dropboxignore /app/bin/dropboxignore.sh
+     - sudo make install
+     - install -D src/bin/cli.sh /app/bin/dropboxignore.sh
      - install -Dm644 docs/static/icons/64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png
      - install -Dm644 docs/static/icons/128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
      - install -Dm644 docs/static/icons/256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png


### PR DESCRIPTION
This PR aims to update the flathub recipes in order to install the latest version of dropboxignore properly